### PR TITLE
RESTful API Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/storage
 /public/css/*.css
 /storage/*.key
+storage/api-docs/*
 /vendor
 .env
 .env.backup

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ yarn install
 yarn dev
 php artisan migrate
 ```
+
+## API Access
+
+Foteaux data can be accessed through a RESTful API
+
+### Tokens
+
+After logging into the web interface, API tokens can be generated at `/user/api-tokens` URI. After obtaining an API token, it should be included in all request headers as `Authorization: Bearer xyz`

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Foteaux data can be accessed through a RESTful API
 ### Tokens
 
 After logging into the web interface, API tokens can be generated at `/user/api-tokens` URI. After obtaining an API token, it should be included in all request headers as `Authorization: Bearer xyz`
+
+### Documentation
+
+Full API documentation can be generated with `php artisan l5-swagger:generate`. After running this command, documentation will be published to the `/api/v1` URI.

--- a/app/Actions/Follow.php
+++ b/app/Actions/Follow.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+
+class Follow
+{
+    public function __invoke(User $user): void
+    {
+        auth()->user()?->following()->attach($user);
+    }
+}

--- a/app/Actions/Unfollow.php
+++ b/app/Actions/Unfollow.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+
+class Unfollow
+{
+    public function __invoke(User $user): void
+    {
+        auth()->user()?->following()->detach($user);
+    }
+}

--- a/app/Http/Controllers/Api/Controller.php
+++ b/app/Http/Controllers/Api/Controller.php
@@ -8,9 +8,9 @@
  * )
  *
  * @OA\SecurityScheme(
- *   securityScheme="BasicAuth",
+ *   securityScheme="bearerAuth",
  *   type="http",
- *   scheme="basic"
+ *   scheme="bearer"
  * )
  **/
 

--- a/app/Http/Controllers/Api/Controller.php
+++ b/app/Http/Controllers/Api/Controller.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @OA\Server(url="/api/v1")
+ *
+ * @OA\Info(
+ *    title="Foteaux API",
+ *    version="1.0.0",
+ * )
+ **/
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller as BaseController;
+
+class Controller extends BaseController
+{
+}

--- a/app/Http/Controllers/Api/Controller.php
+++ b/app/Http/Controllers/Api/Controller.php
@@ -6,6 +6,12 @@
  *    title="Foteaux API",
  *    version="1.0.0",
  * )
+ *
+ * @OA\SecurityScheme(
+ *   securityScheme="BasicAuth",
+ *   type="http",
+ *   scheme="basic"
+ * )
  **/
 
 namespace App\Http\Controllers\Api;

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -13,7 +13,7 @@ class FeedController extends Controller
      *     path="/feed",
      *     summary="Retrieve authenticated user's media feed",
      *     operationId="readUserFeed",
-     *     security={{"BasicAuth": {}}},
+     *     security={{"bearerAuth": {}}},
      *     tags={"user"},
      *     @OA\Response(
      *        response=200,

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -13,7 +13,7 @@ class FeedController extends Controller
      *     summary="Retrieve authenticated user's media feed",
      *     operationId="readUserFeed",
      *     security={{"bearerAuth": {}}},
-     *     tags={"user"},
+     *     tags={},
      *     @OA\Response(
      *        response=200,
      *        description="Successful media retrieval",

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Api\Controller;
 use App\Http\Resources\Media as MediaResource;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -18,7 +18,7 @@ class FeedController extends Controller
      *        response=200,
      *        description="Successful media retrieval",
      *        @OA\JsonContent(
-     *           @OA\Property(property="data", ref="#/components/schemas/Media")
+     *           @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/Media"))
      *        )
      *     )
      * )

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -18,7 +18,22 @@ class FeedController extends Controller
      *        response=200,
      *        description="Successful media retrieval",
      *        @OA\JsonContent(
-     *           @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/Media"))
+     *           @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/Media")),
+     *           @OA\Property(property="links", type="array", @OA\Items(
+     *               @OA\Property(property="first", type="string", example="https://foteaux.test/api/v1/feed?page=1"),
+     *               @OA\Property(property="last", type="string", example="https://foteaux.test/api/v1/feed?page=3"),
+     *               @OA\Property(property="prev", type="string", example="https://foteaux.test/api/v1/feed?page=1"),
+     *               @OA\Property(property="next", type="string", example="https://foteaux.test/api/v1/feed?page=3")
+     *           )),
+     *           @OA\Property(property="meta", type="array", @OA\Items(
+     *               @OA\Property(property="current_page", type="number"),
+     *               @OA\Property(property="from", type="number", example="16"),
+     *               @OA\Property(property="last_page", type="number", example="3"),
+     *               @OA\Property(property="path", type="string", example="https://foteaux.test/api/v1/feed?page=2"),
+     *               @OA\Property(property="per_page", type="number", example="15"),
+     *               @OA\Property(property="to", type="number", example="30"),
+     *               @OA\Property(property="total", type="number", example="38")
+     *           ))
      *        )
      *     )
      * )

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Resources\Media as MediaResource;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class FeedController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/feed",
+     *     summary="Retrieve authenticated user's media feed",
+     *     operationId="readUserFeed",
+     *     tags={"user"},
+     *     @OA\Response(
+     *        response=200,
+     *        description="Successful media retrieval",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="data", ref="#/components/schemas/Media")
+     *        )
+     *     )
+     * )
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        return MediaResource::collection(auth()->user()?->feed_media->paginate() ?? []);
+    }
+}

--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -13,6 +13,7 @@ class FeedController extends Controller
      *     path="/feed",
      *     summary="Retrieve authenticated user's media feed",
      *     operationId="readUserFeed",
+     *     security={{"BasicAuth": {}}},
      *     tags={"user"},
      *     @OA\Response(
      *        response=200,

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -13,7 +13,7 @@ class UserController extends Controller
      *     path="/users/{username}",
      *     summary="Retrieve user record",
      *     operationId="readUser",
-     *     security={{"BasicAuth": {}}},
+     *     security={{"bearerAuth": {}}},
      *     tags={"user"},
      *     @OA\Parameter(
      *         description="User account username",

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Api\Controller;
 use App\Http\Resources\User as UserResource;
 use App\Models\User;
 

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -13,6 +13,7 @@ class UserController extends Controller
      *     path="/users/{username}",
      *     summary="Retrieve user record",
      *     operationId="readUser",
+     *     security={{"BasicAuth": {}}},
      *     tags={"user"},
      *     @OA\Parameter(
      *         description="User account username",

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Resources\User as UserResource;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/users/{username}",
+     *     summary="Retrieve user record",
+     *     operationId="readUser",
+     *     tags={"user"},
+     *     @OA\Parameter(
+     *         description="User account username",
+     *         in="path",
+     *         name="username",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *          example="johnsmith"
+     *         )
+     *     ),
+     *     @OA\Response(
+     *        response=200,
+     *        description="Successful user record lookup",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="data", ref="#/components/schemas/User")
+     *        )
+     *     ),
+     *     @OA\Response(
+     *        response=404,
+     *        description="Record not found",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="success", type="boolean", example="false")
+     *        )
+     *     )
+     * )
+     */
+    public function show(User $user): UserResource
+    {
+        return new UserResource($user);
+    }
+}

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Http\Requests\UserUpdate as UserUpdateRequest;
 use App\Http\Resources\User as UserResource;
 use App\Models\User;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class UserController extends Controller
 {
@@ -40,8 +42,61 @@ class UserController extends Controller
      *     )
      * )
      */
-    public function show(User $user): UserResource
+    public function show(User $user): JsonResource
     {
         return new UserResource($user);
+    }
+
+    /**
+     * @OA\Patch(
+     *     path="/users/{username}",
+     *     summary="Update user record",
+     *     operationId="readUser",
+     *     security={{"bearerAuth": {}}},
+     *     tags={"user"},
+     *     @OA\Parameter(
+     *         description="User account username",
+     *         in="path",
+     *         name="username",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *          example="johnsmith"
+     *         )
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         description="User attributes to update",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", example="John Smith"),
+     *             @OA\Property(property="email", type="string", example="jsmith@foteaux.io"),
+     *             @OA\Property(property="username", type="string", example="jsmith"),
+     *         ),
+     *     ),
+     *     @OA\Response(
+     *        response=200,
+     *        description="Successful user record update",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="data", ref="#/components/schemas/User")
+     *        )
+     *     ),
+     *     @OA\Response(
+     *        response=404,
+     *        description="Record not found",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="success", type="boolean", example="false")
+     *        )
+     *     )
+     * )
+     */
+    public function update(User $user, UserUpdateRequest $request): JsonResource
+    {
+        $user->update($request->only([
+            'name',
+            'email',
+            'username',
+        ]));
+
+        return $this->show($user);
     }
 }

--- a/app/Http/Controllers/Api/UserFollowController.php
+++ b/app/Http/Controllers/Api/UserFollowController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Actions\Follow;
+use App\Actions\Unfollow;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+
+class UserFollowController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/users/{username}/follow",
+     *     summary="Unfollow a user account",
+     *     operationId="createUserFollow",
+     *     tags={"user","groups"},
+     *     @OA\Parameter(
+     *         description="User account username",
+     *         in="path",
+     *         name="username",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *          example="johnsmith"
+     *         )
+     *     ),
+     *     @OA\Response(
+     *        response=204,
+     *        description="Successful follow association"
+     *     ),
+     *     @OA\Response(
+     *        response=422,
+     *        description="Action unsuccessful",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="success", type="boolean", example="false")
+     *        )
+     *     )
+     * )
+     */
+    public function store(User $user): JsonResponse
+    {
+        if ($user->is(auth()->user())) {
+            return response()->json([
+                'success' => false,
+            ], 406);
+        }
+        (new Follow())($user);
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/users/{username}/follow",
+     *     summary="Unfollow a user account",
+     *     operationId="deleteUserFollow",
+     *     tags={"user","groups"},
+     *     @OA\Parameter(
+     *         description="User account username",
+     *         in="path",
+     *         name="username",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *          example="johnsmith"
+     *         )
+     *     ),
+     *     @OA\Response(
+     *        response=204,
+     *        description="Successful unfollow association"
+     *     ),
+     *     @OA\Response(
+     *        response=422,
+     *        description="Action unsuccessful",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="success", type="boolean", example="false")
+     *        )
+     *     )
+     * )
+     */
+    public function delete(User $user): JsonResponse
+    {
+        (new Unfollow())($user);
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/Api/UserFollowController.php
+++ b/app/Http/Controllers/Api/UserFollowController.php
@@ -15,7 +15,7 @@ class UserFollowController extends Controller
      *     path="/users/{username}/follow",
      *     summary="Unfollow a user account",
      *     operationId="createUserFollow",
-     *     tags={"user","groups"},
+     *     tags={"user","follows"},
      *     @OA\Parameter(
      *         description="User account username",
      *         in="path",
@@ -56,7 +56,7 @@ class UserFollowController extends Controller
      *     path="/users/{username}/follow",
      *     summary="Unfollow a user account",
      *     operationId="deleteUserFollow",
-     *     tags={"user","groups"},
+     *     tags={"user","follows"},
      *     @OA\Parameter(
      *         description="User account username",
      *         in="path",

--- a/app/Http/Controllers/Api/UserMediaController.php
+++ b/app/Http/Controllers/Api/UserMediaController.php
@@ -14,6 +14,7 @@ class UserMediaController extends Controller
      *     path="/users/{username}/media",
      *     summary="Retrieve user media records",
      *     operationId="readUserMedia",
+     *     security={{"BasicAuth": {}}},
      *     tags={"user", "media"},
      *     @OA\Parameter(
      *         description="User account username",

--- a/app/Http/Controllers/Api/UserMediaController.php
+++ b/app/Http/Controllers/Api/UserMediaController.php
@@ -14,7 +14,7 @@ class UserMediaController extends Controller
      *     path="/users/{username}/media",
      *     summary="Retrieve user media records",
      *     operationId="readUserMedia",
-     *     security={{"BasicAuth": {}}},
+     *     security={{"bearerAuth": {}}},
      *     tags={"user", "media"},
      *     @OA\Parameter(
      *         description="User account username",

--- a/app/Http/Controllers/Api/UserMediaController.php
+++ b/app/Http/Controllers/Api/UserMediaController.php
@@ -29,7 +29,22 @@ class UserMediaController extends Controller
      *        response=200,
      *        description="Successful user media records lookup",
      *        @OA\JsonContent(
-     *           @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/Media"))
+     *           @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/Media")),
+     *           @OA\Property(property="links", type="array", @OA\Items(
+     *               @OA\Property(property="first", type="string", example="https://foteaux.test/api/v1/users/jsmith/media?page=1"),
+     *               @OA\Property(property="last", type="string", example="https://foteaux.test/api/v1/users/jsmith/media?page=3"),
+     *               @OA\Property(property="prev", type="string", example="https://foteaux.test/api/v1/users/jsmith/media?page=1"),
+     *               @OA\Property(property="next", type="string", example="https://foteaux.test/api/v1/users/jsmith/media?page=3")
+     *           )),
+     *           @OA\Property(property="meta", type="array", @OA\Items(
+     *               @OA\Property(property="current_page", type="number"),
+     *               @OA\Property(property="from", type="number", example="16"),
+     *               @OA\Property(property="last_page", type="number", example="3"),
+     *               @OA\Property(property="path", type="string", example="https://foteaux.test/api/v1/users/jsmith/media?page=2"),
+     *               @OA\Property(property="per_page", type="number", example="15"),
+     *               @OA\Property(property="to", type="number", example="30"),
+     *               @OA\Property(property="total", type="number", example="38")
+     *           ))
      *        )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/Api/UserMediaController.php
+++ b/app/Http/Controllers/Api/UserMediaController.php
@@ -14,7 +14,7 @@ class UserMediaController extends Controller
      *     summary="Retrieve user media records",
      *     operationId="readUserMedia",
      *     security={{"bearerAuth": {}}},
-     *     tags={"user", "media"},
+     *     tags={"user"},
      *     @OA\Parameter(
      *         description="User account username",
      *         in="path",

--- a/app/Http/Controllers/Api/UserMediaController.php
+++ b/app/Http/Controllers/Api/UserMediaController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\Controller;
+use App\Http\Resources\Media;
+use App\Models\User;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class UserMediaController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/users/{username}/media",
+     *     summary="Retrieve user media records",
+     *     operationId="readUserMedia",
+     *     tags={"user", "media"},
+     *     @OA\Parameter(
+     *         description="User account username",
+     *         in="path",
+     *         name="username",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *          example="johnsmith"
+     *         )
+     *     ),
+     *     @OA\Response(
+     *        response=200,
+     *        description="Successful user media records lookup",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/Media"))
+     *        )
+     *     ),
+     *     @OA\Response(
+     *        response=404,
+     *        description="Record not found",
+     *        @OA\JsonContent(
+     *           @OA\Property(property="success", type="boolean", example="false")
+     *        )
+     *     )
+     * )
+     */
+    public function index(User $user): AnonymousResourceCollection
+    {
+        return Media::collection($user->media()->paginate(10));
+    }
+}

--- a/app/Http/Controllers/Api/UserMediaController.php
+++ b/app/Http/Controllers/Api/UserMediaController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Api\Controller;
 use App\Http\Resources\Media;
 use App\Models\User;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;

--- a/app/Http/Livewire/FollowButton.php
+++ b/app/Http/Livewire/FollowButton.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Livewire;
 
+use App\Actions\Follow;
+use App\Actions\Unfollow;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
@@ -17,11 +19,11 @@ class FollowButton extends Component
 
     public function follow(): void
     {
-        auth()->user()?->following()->attach($this->user);
+        (new Follow())($this->user);
     }
 
     public function unfollow(): void
     {
-        auth()->user()?->following()->detach($this->user);
+        (new Unfollow())($this->user);
     }
 }

--- a/app/Http/Requests/UserUpdate.php
+++ b/app/Http/Requests/UserUpdate.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UserUpdate extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return auth()->user() && auth()->id() == request()->route('user')?->id;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => [
+                'string',
+                'max:255',
+                Rule::requiredIf(fn () => ! request()->is('api/*')),
+            ],
+            'email' => [
+                'email',
+                'max:255',
+                Rule::unique('users')->ignore(request()->route('user') ?? null),
+                Rule::requiredIf(fn () => ! request()->is('api/*')),
+            ],
+            'username' => [
+                'max:20',
+                'alpha_num',
+                Rule::unique('users')->ignore(request()->route('user') ?? null),
+                Rule::requiredIf(fn () => ! request()->is('api/*')),
+            ],
+            'photo' => [
+                'nullable',
+                'mimes:jpg,jpeg,png',
+                'max:1024',
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/Media.php
+++ b/app/Http/Resources/Media.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @OA\Schema(
+ *   schema="Media",
+ *   type="object",
+ *   description="Media item",
+ *   allOf={
+ *       @OA\Schema(
+ *           @OA\Property(property="id", type="number"),
+ *           @OA\Property(property="url", type="string"),
+ *           @OA\Property(property="user", ref="#/components/schemas/User")
+ *       )
+ *   }
+ * )
+ **/
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Media extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id'   => $this->id,
+            'url'  => $this->url,
+            'user' => new User($this->user),
+        ];
+    }
+}

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @OA\Schema(
+ *   schema="User",
+ *   type="object",
+ *   description="User details",
+ *   allOf={
+ *       @OA\Schema(
+ *           @OA\Property(property="id", type="number"),
+ *           @OA\Property(property="name", type="string"),
+ *           @OA\Property(property="username", type="string")
+ *       )
+ *   }
+ * )
+ **/
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class User extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id'       => $this->id,
+            'name'     => $this->name,
+            'username' => $this->username,
+        ];
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -38,10 +38,10 @@ class RouteServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
 
         $this->routes(function () {
-            Route::prefix('api')
+            Route::prefix('api/v1')
                 ->middleware('api')
-                ->namespace($this->namespace)
-                ->group(base_path('routes/api.php'));
+                ->namespace(sprintf('%s/api', $this->namespace))
+                ->group(base_path('routes/api/v1.php'));
 
             Route::middleware('web')
                 ->namespace($this->namespace)

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "nunomaduro/larastan": "^0.7.12"
     },
     "require-dev": {
+        "darkaonline/l5-swagger": "^8.0",
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
         "friendsofphp/php-cs-fixer": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3c0b27f206c61ff901aa4e81865f715",
+    "content-hash": "c5a7f29e3037722ea228fdd345bf4e97",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7077,6 +7077,85 @@
     ],
     "packages-dev": [
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "8.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "5e3d9c067797ebc35304d20acd94aeb40cde2825"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/5e3d9c067797ebc35304d20acd94aeb40cde2825",
+                "reference": "5e3d9c067797ebc35304d20acd94aeb40cde2825",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": ">=8.40.0 || ^7.0",
+                "php": "^7.2 || ^8.0",
+                "swagger-api/swagger-ui": "^3.0",
+                "symfony/yaml": "^5.0",
+                "zircote/swagger-php": "3.*"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "6.* || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "8.*"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ],
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/8.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-12T06:31:40+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.13.1",
             "source": {
@@ -9689,6 +9768,67 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "swagger-api/swagger-ui",
+            "version": "v3.51.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "4c29a94daa8271096fd3e2aa34516e07a8932cf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/4c29a94daa8271096fd3e2aa34516e07a8932cf4",
+                "reference": "4c29a94daa8271096fd3e2aa34516e07a8932cf4",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v3.51.2"
+            },
+            "time": "2021-07-30T10:10:42+00:00"
+        },
+        {
             "name": "symfony/options-resolver",
             "version": "v5.3.4",
             "source": {
@@ -9888,6 +10028,81 @@
             "time": "2021-07-10T08:58:57+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "symfony/console": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v5.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-29T06:20:01+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.1",
             "source": {
@@ -9936,6 +10151,77 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "41ed0eb1dacebe2c365623b3f9ab13d1531a03da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/41ed0eb1dacebe2c365623b3f9ab13d1531a03da",
+                "reference": "41ed0eb1dacebe2c365623b3f9ab13d1531a03da",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.7",
+                "ext-json": "*",
+                "php": ">=7.2",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
+                "phpunit/phpunit": ">=8"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/3.2.3"
+            },
+            "time": "2021-06-25T04:08:57+00:00"
         }
     ],
     "aliases": [],

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -44,7 +44,7 @@ return [
     'features' => [
         // Features::termsAndPrivacyPolicy(),
         Features::profilePhotos(),
-        // Features::api(),
+        Features::api(),
         // Features::teams(['invitations' => true]),
         Features::accountDeletion(),
     ],

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,247 @@
+<?php
+
+return [
+    'default'        => 'v1',
+    'documentations' => [
+        'v1' => [
+            'api' => [
+                'title' => 'API Documentation',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                */
+                'api'  => 'api/v1',
+                'docs' => 'api/v1/docs',
+            ],
+            'paths' => [
+                /*
+                 * File name of the generated json documentation file
+                */
+                'docs_json' => 'v1.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                */
+                'docs_yaml' => 'v1.yaml',
+
+                /*
+                * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+            */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+            */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+            */
+            'middleware' => [
+                'api'             => [],
+                'asset'           => [],
+                'docs'            => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+            */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+            */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+            */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+            */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Edit to set path where swagger ui assets should be stored
+            */
+            'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+            /*
+             * Absolute path to directories that should be exclude from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+            */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /*
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /*
+             * analysis: defaults to a new \OpenApi\Analysis .
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /*
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /*
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be exclude from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+            */
+            'exclude' => [],
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+        */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+        */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+        */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+        */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+        */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+        */
+        'validator_url' => null,
+
+        /*
+         * Persist authorization login after refresh browser
+         */
+        'persist_authorization' => true,
+
+        /*
+         * Uncomment to add constants which can be used in annotations
+         */
+        // 'constants' => [
+        // 'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        // ],
+    ],
+];

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Http\Request;
+use App\Http\Controllers\Api\FeedController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -14,6 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/feed', [ FeedController::class, 'index' ]);
 });

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\Api\FeedController;
+use App\Http\Controllers\Api\UserController;
+use App\Http\Controllers\Api\UserMediaController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -16,4 +18,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/feed', [ FeedController::class, 'index' ]);
+
+    Route::get('/users/{user:username}', [ UserController::class, 'show' ]);
+    Route::get('/users/{user:username}/media', [ UserMediaController::class, 'index' ]);
 });

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\FeedController;
 use App\Http\Controllers\Api\UserController;
+use App\Http\Controllers\Api\UserFollowController;
 use App\Http\Controllers\Api\UserMediaController;
 use Illuminate\Support\Facades\Route;
 
@@ -19,6 +20,11 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/feed', [ FeedController::class, 'index' ]);
 
-    Route::get('/users/{user:username}', [ UserController::class, 'show' ]);
-    Route::get('/users/{user:username}/media', [ UserMediaController::class, 'index' ]);
+    Route::prefix('/users/{user:username}')->group(function () {
+        Route::get('', [ UserController::class, 'show' ]);
+        Route::get('media', [ UserMediaController::class, 'index' ]);
+
+        Route::get('follow', [ UserFollowController::class, 'store' ]);
+        Route::delete('follow', [ UserFollowController::class, 'delete' ]);
+    });
 });

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -17,16 +17,16 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->group(function () {
-    Route::get('/feed', [ FeedController::class, 'index' ]);
+Route::middleware('auth:sanctum')->name('api.v1.')->group(function () {
+    Route::get('/feed', [ FeedController::class, 'index' ])->name('feed');
 
-    Route::prefix('/users/{user:username}')->group(function () {
-        Route::get('', [ UserController::class, 'show' ]);
-        Route::patch('', [ UserController::class, 'update' ]);
+    Route::prefix('/users/{user:username}')->name('user.')->group(function () {
+        Route::get('', [ UserController::class, 'show' ])->name('show');
+        Route::patch('', [ UserController::class, 'update' ])->name('update');
 
-        Route::get('media', [ UserMediaController::class, 'index' ]);
+        Route::get('media', [ UserMediaController::class, 'index' ])->name('media');
 
-        Route::post('follow', [ UserFollowController::class, 'store' ]);
-        Route::delete('follow', [ UserFollowController::class, 'delete' ]);
+        Route::post('follow', [ UserFollowController::class, 'store' ])->name('follow.store');
+        Route::delete('follow', [ UserFollowController::class, 'delete' ])->name('follow.delete');
     });
 });

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -22,9 +22,11 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::prefix('/users/{user:username}')->group(function () {
         Route::get('', [ UserController::class, 'show' ]);
+        Route::patch('', [ UserController::class, 'update' ]);
+
         Route::get('media', [ UserMediaController::class, 'index' ]);
 
-        Route::get('follow', [ UserFollowController::class, 'store' ]);
+        Route::post('follow', [ UserFollowController::class, 'store' ]);
         Route::delete('follow', [ UserFollowController::class, 'delete' ]);
     });
 });

--- a/tests/Feature/Api/FeedTest.php
+++ b/tests/Feature/Api/FeedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FeedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_returns_feed()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+        $following = User::factory()->hasMedia(3)->create();
+        $user->following()->attach($following);
+
+        $this->actingAs($user)->get(route('api.v1.feed'))
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data'  => [],
+                'links' => [],
+                'meta'  => [],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_errors_for_guests()
+    {
+        $this->get(route('api.v1.feed'))->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Api/UserFollowTest.php
+++ b/tests/Feature/Api/UserFollowTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UserFollowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_follows_users()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+        $following = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('api.v1.user.follow.store', $following))
+            ->assertNoContent();
+
+        $this->assertTrue($user->following->contains($following));
+    }
+
+    /**
+     * @test
+     */
+    public function it_unfollows_users()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+        $following = User::factory()->create();
+        $user->following()->attach($following);
+
+        $this->actingAs($user)
+            ->delete(route('api.v1.user.follow.delete', $following))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('follows', [
+            'user_id'         => $user->id,
+            'follows_user_id' => $following->id,
+        ]);
+
+        $this->assertFalse($user->following->contains($following));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_error_when_following_self()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('api.v1.user.follow.store', $user))
+            ->assertStatus(406);
+
+        $this->assertDatabaseMissing('follows', [
+            'user_id'         => $user->id,
+            'follows_user_id' => $user->id,
+        ]);
+
+        $this->assertFalse($user->following->contains($user));
+    }
+}

--- a/tests/Feature/Api/UserMediaTest.php
+++ b/tests/Feature/Api/UserMediaTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UserMediaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_returns_user_media()
+    {
+        Storage::fake();
+
+        $user = User::factory()->hasMedia(3)->create();
+
+        $this->actingAs($user)
+            ->get(route('api.v1.user.media', $user))
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'url',
+                        'user' => [
+                            'id',
+                            'name',
+                            'username',
+                        ],
+                    ],
+                ],
+                'links' => [],
+                'meta'  => [],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_other_user_media()
+    {
+        Storage::fake();
+
+        $user = User::factory()->hasMedia(3)->create();
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('api.v1.user.media', $user))
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'url',
+                        'user' => [
+                            'id',
+                            'name',
+                            'username',
+                        ],
+                    ],
+                ],
+                'links' => [],
+                'meta'  => [],
+            ]);
+    }
+}

--- a/tests/Feature/Api/UserTest.php
+++ b/tests/Feature/Api/UserTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /**
+     * @test
+     */
+    public function it_returns_user_profile_data()
+    {
+        Storage::fake();
+
+        $user = User::factory()->hasMedia(3)->create();
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('api.v1.user.show', $user))
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                    'username',
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_other_user_profile_data()
+    {
+        Storage::fake();
+
+        $user = User::factory()->hasMedia(3)->create();
+
+        $this->actingAs(User::factory()->create())->get(route('api.v1.user.show', $user))
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                    'username',
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_updates_to_own_profile()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+        $data = [
+            'name'     => $this->faker->name(),
+            'email'    => $this->faker->email(),
+            'username' => $this->faker->word(),
+        ];
+
+        $this->actingAs($user)
+            ->patch(route('api.v1.user.update', $user), $data)
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                    'username',
+                ],
+            ]);
+
+        $this->assertEmpty(
+            array_diff($user->fresh()->only(array_keys($data)), $data)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_updates_to_other_profile()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+        $data = [
+            'name'     => $this->faker->name(),
+            'email'    => $this->faker->email(),
+            'username' => $this->faker->word(),
+        ];
+
+        $this->actingAs(User::factory()->create())
+            ->patch(route('api.v1.user.update', $user), $data)
+            ->assertForbidden();
+
+        $this->assertCount(
+            3,
+            array_diff($user->fresh()->only(array_keys($data)), $data)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_require_all_attributes_when_updating()
+    {
+        Storage::fake();
+
+        $user = User::factory()->create();
+        $data = [
+            'email' => $this->faker->email(),
+        ];
+
+        $this->actingAs($user)
+            ->patch(route('api.v1.user.update', $user), $data)
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                    'username',
+                ],
+            ]);
+
+        $this->assertEmpty(
+            array_diff($user->fresh()->only(array_keys($data)), $data)
+        );
+    }
+}

--- a/tests/Unit/Actions/FollowTest.php
+++ b/tests/Unit/Actions/FollowTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Components;
+
+use App\Actions\Follow;
+use App\Actions\Unfollow;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FollowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_follows_users()
+    {
+        $user = User::factory()->create();
+        $following = User::factory()->create();
+
+        $this->actingAs($user);
+        (new Follow())($following);
+
+        $this->assertTrue($user->following()->get()->contains($following));
+    }
+
+    /**
+     * @test
+     */
+    public function it_unfollows_users()
+    {
+        $user = User::factory()->create();
+        $following = User::factory()->create();
+        $user->following()->attach($following);
+
+        $this->actingAs($user);
+        (new Unfollow())($following);
+
+        $this->assertFalse($user->following()->get()->contains($following));
+    }
+}


### PR DESCRIPTION
Provided RESTful API endpoints for accessing and updating application data. Primarily read-only, with the ability to update a users own account information.

## Test Coverage
- tests/Feature/Api/FeedTest.php 
    - it_returns_feed 
    - it_returns_errors_for_guests 
- tests/Feature/Api/UserFollowTest.php
    - it_follows_users it_unfollows_users
    - it_returns_error_when_following_self
- tests/Feature/Api/UserMediaTest.php 
    - it_returns_user_media 
    - it_returns_other_user_media 
- tests/Feature/Api/UserTest.php 
    - it_returns_user_profile_data 
    - it_returns_other_user_profile_data 
    - it_allows_updates_to_own_profile 
    - it_does_not_allow_updates_to_other_profile 
    - it_does_not_require_all_attributes_when_updating 
- tests/Unit/Actions/FollowTest.php 
    - it_follows_users 
    - it_unfollows_users

## Acceptance Testing Steps
1. Generate your access token at `/user/api-tokens`
1. Using the [provided Paw or Postman files](https://github.com/amsoell/foteaux/files/6912263/foteaux-api-tests.zip), test each of the following API endpoints to ensure their functionality. Be sure to update the request headers to include the `Authorization: Bearer xyz` header.
    - GET /api/v1/feed
    - GET /api/v1/users/{username}
    - PATCH /api/v1/users/{username}
    - GET /api/v1/users/{username}/media
    - POST /api/v1/users/{username}/follow
    - DELETE /api/v1/users/{username}/follow
1. Generate the API documentation with `php artisan l5-swagger:generate`
1. Navigate to `/api/v1` to confirm the documentation has generated correctly